### PR TITLE
Force UTF-8 client character set for Cargo connections

### DIFF
--- a/includes/CargoUtils.php
+++ b/includes/CargoUtils.php
@@ -71,6 +71,9 @@ class CargoUtils {
 			'password' => $dbPassword,
 			'dbname' => $dbName,
 			'tablePrefix' => $dbTablePrefix,
+			// MySQL >= 8.0.22 rejects using binary strings in regular expression functions
+			// such as REGEXP_LIKE(), heavily used across Cargo, so force UTF-8 client charset here.
+			'utf8Mode' => true,
 		);
 
 		if ( $type === "sqlite" ) {


### PR DESCRIPTION
MySQL >= 8.0.22 rejects using binary strings in regular expression functions
such as REGEXP_LIKE(), heavily used across Cargo, so force UTF-8 client charset here.